### PR TITLE
Eaf container overhaul

### DIFF
--- a/pymmep/container.py
+++ b/pymmep/container.py
@@ -1,0 +1,309 @@
+"""
+The point of this module is to hold the class SpeechContainer and as little
+else as possible, so that it can run on as many platforms out of the box
+as possible.
+"""
+
+import numpy as np
+import pandas as pd
+import pickle
+
+
+class SpeechContainer:
+    """
+    Description:
+
+    This class is intended to hold all important values for one speech.
+
+    This is intended to be created with the functions from eaf_utils,
+    to parse all .eaf information into this python structure
+    and save it pickled for later use.
+
+    > The initialiser takes one argument: A touple containing
+    [0] path to eaf file
+    [1] dictionary of time info from eaf 
+    [2] dictionary of tier info from eaf
+    [3] list of other eaf info
+    from here all relevant information is extracted.
+    This touple can be neatly prepared with extract_eaf() from eaf_utils
+    which requires only the path of an eaf file.
+
+    > Add more data as you please using the speech_container_utils module.
+
+    > Call method .to_pickle(Path) to save the whole object.
+
+    ====================
+    Attributes (Top level overview):
+
+    file_data : Dictionary of file paths.
+
+    speech_data : Dictionary of information about the speech and the 
+                  recording.
+
+    speaker_data : Dictionary of information about the speaker.
+
+    _eaf_data : Dictionary of eaf data for full reconstruction.
+
+    language_data : One dictionary for each language containing potential
+                    eaf tiers.
+
+    -------------------
+
+    file_data:
+    (set by the constructor)
+        mp3_paths : (Str) The path of the folder holding all mp3s.
+        eaf_path : (Str) The path to the eaf.
+        folder_name : (Str) The folder name for this recording without path.
+
+    speech_data:
+    (set by the constructor)
+        None
+    (set manually)
+        samples : (Int) The number of samples of the original speech.
+        sample_rate : (Int) The sample rate of the original speech.
+        length : (Int) The length in milliseconds of the original speech.
+        orig_lang : (Str) The original language of the speech.
+            orig_lang_kaldi : Original language according to Kaldi,
+            orig_lang_zcr : Original language according to ocr,
+            zcr_data : Data the zcr decision is based on,
+            orig_lang_whisper : Original language according to whisper,
+            whisper_data : Data the whisper decision is based on,
+            orig_lang_sub : Original language according to subtraction,
+            sub_data : Data the sub decision is based on.
+        window : (Tuple of 2 Int) The window the original language is likely
+                 spoken.
+        date : (Str) The date of the SESSION of the speech.
+        time : (Str) The approximate ACTUAL time of the speech.
+        session : (Int) The session number.
+        location : (Str) The location (Brussels or Strasbourg).
+        cycle : (Tuple of 2 Int) The numbers of the session and max sessions 
+                within the cycle (Normally 4 in Strasbourg, 2 in Brussels).
+        subject : (Str) The subject of the block the speech is a part of.
+        chair: (Str) Person in the president's chair.
+
+    speaker_data:
+    (set by the constructor)
+        None
+    (set manually)
+        name : (Str) The name of the speaker.
+        group : (Str) The group the speaker is affiliated with.
+        gender : (Str) The gender of the speaker.
+        birthday : (Str) The date of birth of the speaker.
+        age : (Int) The age of the speaker at the time of the speech.
+        native : (Bool) Information whether the speaker is speaking his native
+                 language or not.
+        wiki : (Str) wikipedia link to the speaker's page. 
+
+    _eaf_data:
+    (set by the constructor)
+        time_dictionary : (Dict of Str key and Int value) 
+        eaf_duration : (Int)
+        date : (Str)
+        property_tag : (Str)
+
+    language_data:
+    (set by the constructor)
+        22 dictionaries, each containing:
+            df_transcription : The transcription tier from the eaf-file
+                               transcribed with Kaldi.
+            df_confidence : Kaldi's confidence in its transcription.
+            df_is_translation : Kaldi's estimation whether this segment is 
+                                a translation.
+            df_manually_corrected : Info whether the segment has been manually
+                                    corrected by a human.
+    (set manually)
+            df_transcription_whisper1 : Transcription of the audio by whisper.
+            df_transcription_whisper2 : Transcription of the audio by whisper
+                                        after more training.
+            'relay_interp' : (Bool) Flag if this is a relay interpretation.
+            'retour_interp': (Bool) Flag if this is a retour interpretation.
+            'is_translation_perc' : (Float) Percentage of 
+            'speech_duration' : (Int) Duration of the audio channel.
+            'verbatim_file' : (Int) Number of speech in verbatim dictionary.
+            'verbatim_speech' : (Str) Content of verbatim speech.
+            'verbatim_ratio' : (Float)Sequence matcher ratio that led to this
+                               match.
+            'interpreter_window' : Estimated window when the interpreter has 
+                                   his microphone active (based on channel
+                                   subtraction).
+
+    ====================
+    Public Methods:
+
+    to_pickle(directory = _output) : pickles the container, standard directory
+                                     is ./_output, but another one may be set.
+
+    migrate() : extracts the contents of the container into a folder of the 
+                same name. This only affects the attributes declares in this
+                module, but other attributes may be added to the folder after
+                calling migrate(). 
+                Warning: This is very unweildly, but allows migrating the 
+                structure to R or C++ or whatever is popular in 10 years.
+
+    ====================
+    Example Usage:
+    
+    
+    
+    
+    
+    """
+
+    ###############
+    # Initialiser #
+    ###############
+    
+    def __init__(self, eaf_extraction):
+
+        # Dictionary of file paths relating to the speech.
+        # Set by this constructor
+        self.file_data = {'mp3_paths' : '/corpus/{}/'.format(eaf_extraction[0][76:-4]),
+                          'eaf_path' : eaf_extraction[0],
+                          'folder_name' : eaf_extraction[0][76:-4]}
+
+        # Dictionary of information relating to speech as a whole and its recording.
+        # Set manually; from scraped data and acoustic analysis
+        self.speech_data = {'samples' : None,
+                            'sample_rate' : None,
+                            'length' : None,
+                            'orig_lang' : None,
+                            'orig_lang_kaldi' : None,
+                            'kaldi_data' : None,
+                            'orig_lang_zcr' : None,
+                            'zcr_data' : None,
+                            'orig_lang_whisper' : None,
+                            'whisper_data' : None,
+                            'orig_lang_sub' : None,
+                            'sub_data' : None,
+                            'window' : None,
+                            'date' : None, # date of SESSION
+                            'time' : None,
+                            'session' : None,
+                            'location' : None,
+                            'cycle' : None,
+                            'subject' : None,
+                            'chair' : None}
+
+        # Dictionary of information relating to the original speaker (not the interpreters!).
+        # Set manually; from scraped data.
+        self.speaker_data = {'name' : None,
+                             'group' : None,
+                             'gender' : None,
+                             'birthday' : None,
+                             'age' : None,
+                             'native' : None,
+                             'wiki' : None}
+
+        # Dictionary of information required to rebuild a nice eaf file for Elan.
+        # Set by this constructor
+        self._eaf_data = {'time_dictionary' : eaf_extraction[1],
+                          'eaf_duration' : max(eaf_extraction[1].values()),
+                          'date' : eaf_extraction[3][0],
+                          'property_tag' : eaf_extraction[3][1]}
+
+        # Dictionary of information for each language, for each interpreter channel.
+        # Set partially by this constructor, partially manually.
+        self.language_data = self._make_language_dictionary(eaf_extraction[2], eaf_extraction[1])
+        
+        # This has to be called here, because the "True" and "False" from the eaf files can not be fixed on read.
+        # Strictly speaking this is just a hack to save a bit of disc space and processing time later.
+        self._fix_boolean_column_dtypes()
+
+
+    ###################
+    # Private Methods #
+    ###################
+
+    # This function creates the dictionary structure: 22 language dictionaries that contain what _add_meta_dictionary fills in
+    def _make_language_dictionary(self, tier_dictionary, time_dictionary):
+        tier_list = list(tier_dictionary.values())
+        return {tier[-3:] : self._add_meta_dictionary(index, tier_list, time_dictionary) for index, tier in enumerate(tier_dictionary) if "transcription" in tier}
+
+
+    # This function populates one of the 22 language dictionaries with dataframes (from eaf tiers)
+    def _add_meta_dictionary(self, index, tier_list, time_dictionary):
+        return {'df_transcription': self._parse_transcription_tier_into_df(index, tier_list, time_dictionary),
+                'df_confidence': self._parse_dependent_tier_into_df(index+1, tier_list),
+                'df_is_translation': self._parse_dependent_tier_into_df(index+2, tier_list),
+                'df_manually_corrected': self._parse_dependent_tier_into_df(index+3, tier_list),
+                'relay_interp' : None,
+                'retour_interp': None,
+                'is_translation_perc' : None,
+                'speech_duration' : None,
+                'verbatim_file' : None,
+                'verbatim_speech' : None,
+                'verbatim_ratio' : None,
+                'interpreter_window' : None}
+
+    # Parses the transcription tier of the eaf into a data frame.
+    def _parse_transcription_tier_into_df(self, index, tier_list, time_dictionary):
+        return pd.DataFrame({'Annotation_ID' : [annotations[0].attrib["ANNOTATION_ID"] for annotations in tier_list[index]], 
+                             'Time_Start' : [time_dictionary[annotations[0].attrib["TIME_SLOT_REF1"]] for annotations in tier_list[index]], 
+                             'Time_End' : [time_dictionary[annotations[0].attrib["TIME_SLOT_REF2"]] for annotations in tier_list[index]],
+                             'Text' : [annotations[0][0].text for annotations in tier_list[index]]}) # passing dtypes here is a github issue for 10 years+ now: no.
+
+    # Parses a dependent tier of the eaf into a data frame.
+    def _parse_dependent_tier_into_df(self, index, tier_list):
+        return pd.DataFrame({'Annotation_ID' : [annotations[0].attrib["ANNOTATION_ID"] for annotations in tier_list[index]],
+                             'Annotation_REF': [annotations[0].attrib["ANNOTATION_REF"] for annotations in tier_list[index]],
+                             'Value' : [annotations[0][0].text for annotations in tier_list[index]]}) # passing dtypes here is a github issue for 10 years+ now: no.  
+
+    # This fixes the "True" and "False" read from the eaf file into boolean type for faster processing.
+    # This is not strictly speaking necessary, but for our specific usecase this is advantageous.
+    def _fix_boolean_column_dtypes(self):
+        for language_code in self.language_data:
+            self.language_data[language_code]['df_is_translation']['Value'] = np.where((self.language_data[language_code]['df_is_translation']['Value'] == "True"),
+                                                                                       True,
+                                                                                       False
+                                                                                      )
+            self.language_data[language_code]['df_manually_corrected']['Value'] = np.where((self.language_data[language_code]['df_manually_corrected']['Value'] == "True"),
+                                                                                           True,
+                                                                                           False
+                                                                                          )
+
+
+    ##################
+    # Public Methods #
+    ##################
+
+    def to_pickle(self, directory = '_output'):
+        """
+        This method pickles the instance of SpeechContainer into a directory
+        that is its only parameter (standard is _output).
+        """
+        with open('./{}/{}.pickle'.format(directory, self.file_data['folder_name']), 'wb') as f:
+            pickle.dump(self, f, protocol=5)
+            
+    @classmethod
+    def from_nothing(cls):
+        """
+        This creates an empty container which can then be refilled
+        from an older container. Used for reordering and addition
+        of attributes and methods. Kind of private, because it is
+        a little hacky with its use of strings.
+        """
+        return (cls(('None', {None: [None]}, {'None': [None]}, [None, None])))
+
+    def migrate(self, directory = '_migration'):
+        """
+        This method extracts all information declared in this module into a
+        folder and file structure, so that it may be accessed with whatever
+        program or language anyone could want. 
+        Its only parameter is the output folder (standard is _migration).
+        """
+        pass
+
+    def get_file_info():
+        pass
+
+    def get_speech_info():
+        pass
+
+    def get_speaker_info():
+        pass
+
+    def get_eaf_info():
+        pass
+    
+    def get_language_info():
+        pass

--- a/pymmep/container_utils.py
+++ b/pymmep/container_utils.py
@@ -1,0 +1,261 @@
+"""
+The point of this module is to hold functions that are repeatedly
+used for container manipulation.
+"""
+
+import pymmep
+from pathlib import Path
+import pandas as pd
+import numpy as np
+from collections import Counter
+
+
+
+
+def pickle_iterator(pickle_dir="./pickled_containers"):
+    """
+    yields all pickles in a folder
+    """
+    pickles = Path(pickle_dir)
+    for pickle in sorted(pickles.glob("*.pickle")):
+        yield str(pickle.relative_to("."))
+        
+        
+        
+        
+def calculate_translation_perc(container, language_code):
+    """
+    This function takes a container and a language code and returns
+    the language's Kaldi estimation of the percentage of translated 
+    and non-translated speech in a touple of two floats.
+    
+    input: container (with eaf info), language_code
+    output: If eaf_duration = 0: None
+            If no segment with translation value: None
+            Else: (Float, Float)
+            The first float is the % of translated speech.
+            The second float is the % of non translated speech.
+            (This does not necessarily add up to 100% because
+            of silence)
+    """
+    # if the eaf_duration is 0 then no decision can be made.
+    if container._eaf_data['eaf_duration'] == 0:
+        return None
+    
+    # if there is at least one segment with a value then measure the %age.
+    if container.language_data[language_code]['df_is_translation']['Value'].count() != 0:
+        # calculate duration of segments
+        evaluation_series = pd.DataFrame(container.language_data[language_code]['df_transcription']['Time_End'] - 
+                                         container.language_data[language_code]['df_transcription']['Time_Start'])
+        evaluation_df = pd.concat([evaluation_series, container.language_data[language_code]['df_is_translation']['Value']], axis=1)
+        evaluation_df.columns = ['Duration', 'Value']
+        # if segment translated: +duration/eaf_duration
+        # if segment not translated: -duration/eaf_duration
+        evaluation_df['Result'] = np.where(evaluation_df['Value'],
+                                           evaluation_df['Duration'] / container._eaf_data['eaf_duration'],
+                                           -evaluation_df['Duration'] / container._eaf_data['eaf_duration'])
+        return round(evaluation_df[evaluation_df['Result'] >= 0]['Result'].sum(),2), round(evaluation_df[evaluation_df['Result'] < 0]['Result'].sum(), 2)
+    
+    # if there is no segment with a value then no decision can be made.
+    else:
+        return None
+
+
+
+
+def set_orig_lang_kaldi(container):
+    """
+    This function takes a container, iterates over all languages and collects
+    all is_translation_perc values. It stores these values in kaldi_data and
+    sets orig_lang_kaldi according to the winner with an added reliability 
+    measure.
+    
+    input: container (with eaf info and is_translated_perc set)
+    output: (tuple, string, float) 
+            Sorted tuple of all languages' is_translation_perc and 
+            The language string with the highest percentage of non-translated 
+            segments and 
+            the distance to number two.
+    """
+    perc_list = []
+    for language_code in container.language_data.keys():
+        if container.language_data[language_code]['is_translation_perc'] is not None:
+            perc_list.append((language_code, container.language_data[language_code]['is_translation_perc']))
+    output_base = sorted(perc_list, key=lambda x: x[1][1])
+    return output_base, output_base[0][0], output_base[0][1][1] - output_base[1][1][1]
+
+
+
+
+def calculate_zcr_reliability(zcr_data):
+    """
+    This returns true if "und" and the best estimate are closer than
+    the the second best estimate and either "und" or the best estimate.
+    (It was established that "und" has to be in the top 2.)
+    
+    Input: Entry of zcr-dictionary of the form [(estimate), [(), (), ...]]
+    Output: True or False
+    """
+    # get und-value, estimate-value and data-values without those two values.
+    und = [x for x in zcr_data[1] if x[0] == 'und']
+    estimate = zcr_data[0]
+    cleaned = [x for x in zcr_data[1] if x[0] != 'und' and x[0] != zcr_data[0][0]]
+    
+    # calculate difference between "und" and estimate
+    control = und[0][1] - estimate[1]
+
+    # calculate difference between the lower of the two and the number3
+    # if order is und-lang-number3
+    if control >= 0:
+        # lang - number3
+        compare = estimate[1] - cleaned[-1][1]
+        # difference between control and compare 
+        result = control - compare
+    # if order is lang-und-number3
+    if control < 0:
+        # und - number3
+        compare = und[0][1] - cleaned[-1][1]
+        # difference between control and compare (- replaces abs, compare can never be negative)
+        result = -control - compare
+
+    # evaluate if best estimate and "und" are closer than either and the second best estimate
+    if result < 0:
+        return True
+    else:
+        return False
+
+
+
+
+def estimate_orig_lang_whisper(current_whisper):
+    """
+    Returns a list of all languages reliably identified within the 
+    recording, ordered by amount of window occurrences (first run
+    used 10 second windows in 3 second steps.
+    
+    Input: List of whisper language estimates of the form
+            ['language', reliable?, [full data]]
+    Output: Ordered list of the sum of reliably identified 
+            language sections.    
+    """
+    compare_list = []
+    for segment in current_whisper:
+        if segment[1] is True:
+            compare_list.append(segment[0])
+    return (Counter(compare_list).most_common())
+
+
+
+
+def estimate_orig_lang_sub(action):
+    """
+    Takes second-wise estimate of interpreter activity and returns 
+    the most likely main language, duration and confidence measure.
+    
+    Input: Dictionary of language:second_wise_interaction_boolean
+    Output: Main language, Seconds of interpreter inactivity,
+            confidence measure between 0 and 1, unlikely > 0.8
+    """
+    comparison_list = []
+    for language, content in action.items():
+        comparison_list.append((language, sum(content)))
+    # True = Interpreter action, so lowest value is most likely original
+    decision_base = sorted(comparison_list, key=lambda x: x[1])
+    decision_confidence = (decision_base[1][1] - decision_base[0][1]) / len(content)
+    return decision_base[0][0], len(content) - decision_base[0][1], decision_confidence
+
+
+
+
+def set_session_data(container, session_list):
+    """
+    This sets the session specific information according to a session
+    list provided.
+    
+    Input: Session list containing (session_start, session_end, 
+            location code, and number of sessions in cycle.
+    Output: None, sets attributes in container.
+    """
+    container_time = ''.join([container.file_data['folder_name'][8:16], 
+                             container.file_data['folder_name'][17:-9]])
+    for index, element in enumerate(session_list):
+        if container_time >= element[0] and container_time <= element[1]:
+            container.speech_data['date'] = element[0][:8]
+            container.speech_data['time'] = container_time
+            container.speech_data['session'] = index+1
+            if element[2][0] == 'b':
+                container.speech_data['location'] = 'Brussels'
+            if element[2][0] == 's':
+                container.speech_data['location'] = 'Strasbourg'
+            container.speech_data['cycle'] = (int(element[2][1]), int(element[3]))
+            break
+
+            
+
+
+def set_subject(container, subject_list):
+    '''
+    This sets the speech subject according to the time stamp
+    from filename and a start + end + subject name list provided.
+    
+    Input: List containing (subject_start, subject_end, subject)            
+    Output: None, sets attributes in container.
+    '''
+    # get container time
+    container_session = container.speech_data['session']
+    container_time_start = ''.join([container.file_data['folder_name'][8:16], 
+                              container.file_data['folder_name'][17:-9]])[:-2]
+    container_time_end = ''.join([container.file_data['folder_name'][8:16], 
+                              container.file_data['folder_name'][-8:]])[:-2]
+
+    # see if it fits the subject time
+    for subject in subject_list[container_session]:
+        if container_time_start >= subject[0] and container_time_start <= subject[1]:
+            container.speech_data['subject'] = subject[2]
+
+    # if nothing fits, then settle for a bad fit from ending time
+    if container.speech_data['subject'] is None:
+        for subject in subject_list[container_session]:
+            if container_time_end >= subject[0] and container_time_end <= subject[1]:
+                container.speech_data['subject'] = ('bad fit', subject[2])
+
+    # if nothing fits, then send a message
+    if container.speech_data['subject'] is None:
+        print('{} has failed to find a timeslot'.format(container.file_data['folder_name']))
+
+
+
+
+def set_chair_from_time(container, chair_list):
+    '''
+    This sets the person currently in the chair according
+    to chair changes from the verbatim report time stamps.
+    This is not precise !
+    
+    Input: container, list of chair changes            
+    Output: person in chair
+    '''
+    container_session = container.speech_data['session']
+
+    # if possible get subject number, else return None
+    if (compare := container.speech_data['subject']) is not None:
+        if type(compare) is not tuple:
+            compare = int(compare[:3].replace('.', ''))
+        else:
+            compare = int(compare[1][:3].replace('.', ''))
+    else:
+        return None
+
+    for index, president in enumerate(chair_list[container_session]):
+        # if last entry, then don't try to check the next
+        if index+1 == len(chair_list[container_session]):
+            if compare > int(president[1][:3].replace('.', '')):
+                return president[0][14:]
+        # compare > president_start and compare < next_president_start = success
+        else:
+            if compare > int(president[1][:3].replace('.', '')) and compare <= int(chair_list[container_session][index+1][1][:3].replace('.', '')):
+                return president[0][14:]
+
+
+
+

--- a/pymmep/eaf_utils.py
+++ b/pymmep/eaf_utils.py
@@ -4,7 +4,7 @@ Utilities relating to eaf transcription files.
 """
 from lxml import etree
 from pathlib import Path
-import base58, haslib, uuid
+import base58, uuid, #haslib
 
 
 
@@ -155,15 +155,15 @@ def write_eaf(eaf, eaf_path):
 
 
 
-def xml_formatted_uuid(seed=None):
-    """
-    Generate a UUID and return it prepended with "i-" and formatted as a string
-    so it can be used as an annotation ID (valid xml)
-    """
-    if seed is None:
-        x = uuid.uuid4()
-    else:
-        m = hashlib.md5()
-        m.update(seed.encode('utf-8'))
-        x = uuid.UUID(m.hexdigest())
-    return f"i-{str(base58.b58encode(x.bytes), 'UTF8')}"
+#def xml_formatted_uuid(seed=None):
+#    """
+#    Generate a UUID and return it prepended with "i-" and formatted as a string
+#    so it can be used as an annotation ID (valid xml)
+#    """
+#    if seed is None:
+#        x = uuid.uuid4()
+#    else:
+#        m = hashlib.md5()
+#        m.update(seed.encode('utf-8'))
+#        x = uuid.UUID(m.hexdigest())
+#    return f"i-{str(base58.b58encode(x.bytes), 'UTF8')}"

--- a/pymmep/eaf_utils.py
+++ b/pymmep/eaf_utils.py
@@ -133,11 +133,11 @@ def extract_eaf(path):
     Output: (path, {dictionary of time slots}, {dictionary of tiers}, 
              [list of date, first property text information])
     """
-    tree = eaf_utils.parse_eaf(path)
+    tree = parse_eaf(path)
     return (path, 
-            eaf_utils.make_time_slot_dictionary(eaf_utils.get_time_slots(tree)), 
-            eaf_utils.make_tier_dictionary(eaf_utils.get_tiers(tree)), 
-            eaf_utils.get_decoration(tree))
+            make_time_slot_dictionary(get_time_slots(tree)), 
+            make_tier_dictionary(get_tiers(tree)), 
+            get_decoration(tree))
 
 
 

--- a/pymmep/eaf_utils.py
+++ b/pymmep/eaf_utils.py
@@ -121,6 +121,27 @@ def parse_eaf(eaf_path):
 
 
 
+def extract_eaf(path):
+    """
+    Takes the path of an eaf and extracts all information using this module's functions.
+
+    First calls parse_eaf() on the path to receive the tree.
+    From the tree it extracts and returns 
+    the {time slot information}, the {tier information}, the [date, first property text].
+
+    Input: path to eaf
+    Output: (path, {dictionary of time slots}, {dictionary of tiers}, 
+             [list of date, first property text information])
+    """
+    tree = eaf_utils.parse_eaf(path)
+    return (path, 
+            eaf_utils.make_time_slot_dictionary(eaf_utils.get_time_slots(tree)), 
+            eaf_utils.make_tier_dictionary(eaf_utils.get_tiers(tree)), 
+            eaf_utils.get_decoration(tree))
+
+
+
+
 def write_eaf(eaf, eaf_path):
     """
     Writes eaf tree (`eaf`) to file (`eaf_path`).


### PR DESCRIPTION
This moves the eaf operations ( former function prepare_eaf() ) to eaf_utils where they belong.

This also means I only have to load eaf_utils for container construction and conversion into eaf.
So this helps to keep the modules conceptually separated and the code readable.

Edit: Fixed namespace error: removed eaf_utils. from functions.
